### PR TITLE
Fix handling of repo paths in Windows that contain spaces

### DIFF
--- a/wsl/bash/.userfoo.sh
+++ b/wsl/bash/.userfoo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
-DIR_INSTALL_UTILS=$(realpath $( dirname ${BASH_SOURCE[0]:-$0} ) )
+DIR_INSTALL_UTILS=$(realpath "$( dirname "${BASH_SOURCE[0]:-$0}" )" )
 USERNAME=""
 HOMEDIR=""
 
@@ -65,7 +65,7 @@ addSudoers () {
 modifyWslConf () {
   verifyUserName
   echo ${DIR_INSTALL_UTILS}
-  sudo cp ${DIR_INSTALL_UTILS}/wsl.conf /etc/wsl.conf
+  sudo cp "${DIR_INSTALL_UTILS}/wsl.conf" /etc/wsl.conf
   sudo echo "[user]" >> /etc/wsl.conf
   sudo echo "default=${USERNAME}" >> /etc/wsl.conf
 }

--- a/wsl/bash/createUser.sh
+++ b/wsl/bash/createUser.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 set -euo pipefail
-DIR_ME=$(realpath $(dirname $0))
+DIR_ME=$(realpath "$(dirname "$0")")
 
 # this script is called by root an must fail if no user is provided
-. ${DIR_ME}/.userfoo.sh
+. "${DIR_ME}/.userfoo.sh"
 setUserName ${1-""}
 OS_TYPE=${2-"ubuntu"}
 
@@ -33,7 +33,7 @@ createMainUser () {
       chmod 700 ${HOMEDIR}/.ssh
   fi
 
-  cp ${DIR_ME}/nogit/* ${HOMEDIR}/.ssh
+  cp "${DIR_ME}/nogit/"* "${HOMEDIR}/.ssh"
 
   if [[ -f ${HOMEDIR}/.ssh/config ]]; then
       chown ${USERNAME}:${USERNAME} ${HOMEDIR}/.ssh/config

--- a/wsl/bash/sudoNoPasswd.sh
+++ b/wsl/bash/sudoNoPasswd.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
-DIR_ME=$(realpath $(dirname $0))
+DIR_ME=$(realpath "$(dirname "$0")")
 
 # this script is called by root an must fail if no user is provided
-. ${DIR_ME}/.userfoo.sh
-setUserName ${1-""}
+. "${DIR_ME}/.userfoo.sh"
+setUserName "${1-""}"
 
 # no passwd for user when sudo is invoked
 addSudoers "${USERNAME} ALL=(ALL) NOPASSWD:ALL" "${USERNAME}"


### PR DESCRIPTION
When placing the repo on Windows e.g. for the initial setup, stuff breaks.

Here is a fix for that :-)